### PR TITLE
fix I/O error in MembershipFunctionGenBell

### DIFF
--- a/src/net/sourceforge/jFuzzyLogic/membership/MembershipFunctionGenBell.java
+++ b/src/net/sourceforge/jFuzzyLogic/membership/MembershipFunctionGenBell.java
@@ -64,12 +64,12 @@ public class MembershipFunctionGenBell extends MembershipFunctionContinuous {
 	 */
 	@Override
 	public String toString() {
-		return getName() + " : " + " , " + parameters[0] + parameters[1] + " , " + parameters[2];
+		return getName() + " : "  + parameters[1] + " , " + parameters[2] + " , " + parameters[0];
 	}
 
 	/** FCL representation */
 	@Override
 	public String toStringFcl() {
-		return "GBELL " + parameters[0] + " " + parameters[1] + " " + parameters[2];
+		return "GBELL " + parameters[1] + " " + parameters[2] + " " + parameters[0];
 	}
 }


### PR DESCRIPTION
Generalized bells membership functions are not writen and read in the same way, when it's saved in a FCL file.

jFuzzyLogic read GenBell in FCL like that: 
GBELL : a b mean

but write it like that:
GBELL : mean a b

I just switch some parameters in toString and toStringFCL functions  to fix that